### PR TITLE
fix: cannot upload to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ name: "Build and Release"
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
 
 run-name: Release Latest build
 jobs:


### PR DESCRIPTION
1. Add tag_name to automatically create a latest tag
2. Set correct permission. refer to https://github.com/softprops/action-gh-release/issues/236